### PR TITLE
共通 aタグの色設定をヘッダー・フッターに限定する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,10 +17,7 @@
  @import "bootstrap";
 
 
-
 a,a:hover,a:visited{
-  color:white;
-
   text-decoration: none;
 }
 // テキストボックス
@@ -81,6 +78,12 @@ header,footer{
   color:White;
   margin: 0 20px;
   padding:10px 0;
+    a,a:visited{
+      color:white;
+    }
+    a:hover{
+      color:lightgray;
+    }
 }
 footer{
   text-align: center;


### PR DESCRIPTION
aタグの色設定をヘッダー・フッター向けに設定していたので対象を限定する