### PR TITLE
商品一覧画面　商品名検索機能作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -113,9 +113,18 @@ footer{
  display: inline;
  padding:0 5px;
 }
-.itemname-search-txt{
+#q_title_name_cont{
   margin-top:5px;
   width: 300px;
+  color: #000;
+  border-radius: 3px;
+  padding-right: 50px;
+}
+.search_icon{
+  color:#000;
+  position: absolute;
+  margin: -30px;
+  top:42px;
 }
 // サインアップ・ログインフォーム
 .form-div{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,11 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
     @genres = Genre.all
+    @q = Item.search(params[:q])
+    @items = @q.result(distinct: true)
+  end
+
+  def search_params
+    params.require(:q).permit(:title_name_cont)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,7 +6,7 @@
       </div>
       <ul class="genre_list">
       <% @genres.each do |genre| %>
-        <%= link_to search_genre_path(genre.id),target: "self" do %>
+        <%= link_to items_path,target: "self" do %>
           <li><img src="no_image.png" class="genre_image"><%= genre.genre_name %></li>
         <% end %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,10 @@
             <div class="row">
               <div class="col-md-12">
                 <!--商品検索フォーム-->
-                <input type="text" class="itemname-search-txt">
+                <%= search_form_for @q,enforce_utf8: false do |f| %>
+                  <%= f.search_field :title_name_cont %>
+                  <span class="glyphicon glyphicon-search search_icon"></span>
+                <% end %>
               </div>
             </div>
             <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,10 +37,5 @@ namespace :admins do
  get "/users/:id",:to=>"users#show"
 end
 
- get 'items/search/:id', to: 'items#search_genre', as: :search_genre
-
-
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
-
-


### PR DESCRIPTION
商品名検索作成
ransack利用時はindexアクションが呼ばれるため、期待したURLでの実装はできていない
伴い、route.rbの記述を削除したため、ジャンル検索機能のリンクを仮のものに置き換えた