### PR TITLE
商品詳細画面　has_many属性の修正漏れ

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,10 +40,10 @@
         </tr>
       </table>
       <!--収録CD,曲名表示-->
-      <% @item.cd_item.each do |cd| %>
+      <% @item.cd_items.each do |cd| %>
       <p class="cd_title"><%= cd.cd_title %></p>
       <table class="table">
-        <% cd.song.each do |song| %>
+        <% cd.songs.each do |song| %>
         <tr>
           <td><%=song.song_number %>.<%= song.song_title %></td>
         </tr>


### PR DESCRIPTION
view側でhas_manyの設定を利用して子要素を参照している箇所を複数にする対応が漏れていました。
sをつけただけですので、お手数ですが、そのままマージしていただいて結構です。