### PR TITLE
商品一覧画面　利用者ヘッダー・検索フォームを別ファイルに反映　検索処理の初期化処理が不足していたため追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,14 +1,20 @@
 class ItemsController < ApplicationController
   def index
+    item_search_init
     @genres = Genre.all
+  end
+
+  def show
+    item_search_init
+    @item = Item.find(params[:id])
+  end
+
+  private
+  def item_search_init
     @q = Item.search(params[:q])
     @items = @q.result(distinct: true)
   end
-
   def search_params
     params.require(:q).permit(:title_name_cont)
-  end
-  def show
-    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -20,7 +20,7 @@
       <% @items.each do |item| %>
         <li>
           <ul class="items">
-            <%= link_to item_path(item.id),target: "self" do %>
+            <%= link_to item_path(item.id) do %>
               <li>
                   <%= attachment_image_tag item, :image, :fill, 120, 120, format: 'png', class: "" %>
               </li>

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -1,35 +1,39 @@
 <div class="container">
-  <div class="row">
-    <div class="col-md-3">
-      <div class="logo user_logo">
-        BIGAPPLE
-      </div>
-    </div>
-    <div class="col-md-9">
-      <div class="row">
-        <div class="col-md-12">
-          <!--商品検索フォーム-->
-          <input type="text" class="itemname-search-txt">
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12">
-          <div class="nav">
-            <ul>
-              <% if user_signed_in? %>
-                <li>ユーザ名　<%= current_user.last_name %>  <%= current_user.first_name %> </li>
-                <li><%= link_to 'My Page','#' %></li>
-                <li><%= link_to 'View Cart', '#' %></li>
-                <li><%= link_to 'Sign out',destroy_user_session_path, method: :delete %></li>
-              <% else %>
-                <li><%= link_to 'Home',items_path %></li>
-                <li><%= link_to 'Sign in',new_user_session_path %></li>
-                <li><%= link_to 'Sign up',new_user_registration_path %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+ <div class="row">
+   <div class="col-md-3">
+     <div class="logo user_logo">
+       BIGAPPLE
+     </div>
+   </div>
+   <div class="col-md-9">
+     <div class="row">
+       <div class="col-md-12">
+         <!--商品検索フォーム-->
+         <% if request.path == root_path || request.path.include?('items/') %>
+           <%= search_form_for @q,enforce_utf8: false do |f| %>
+             <%= f.search_field :title_name_cont %>
+             <span class="glyphicon glyphicon-search search_icon"></span>
+           <% end %>
+         <% end %>
+       </div>
+     </div>
+     <div class="row">
+       <div class="col-md-12">
+         <div class="nav">
+           <ul>
+             <% if user_signed_in? %>
+               <li><%= link_to 'My Page','#' %></li>
+               <li><%= link_to 'View Cart', '#' %></li>
+               <li><%= link_to 'Sign out',destroy_user_session_path, method: :delete %></li>
+             <% else %>
+               <li><%= link_to 'Home',items_path %></li>
+               <li><%= link_to 'Sign in',new_user_session_path %></li>
+               <li><%= link_to 'Sign up',new_user_registration_path %></li>
+             <% end %>
+           </ul>
+         </div>
+       </div>
+     </div>
+   </div>
+ </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,44 +11,7 @@
   <body>
     <header>
       <% if request.path.include?('admin') %>
-       <!--<%# render 'layouts/adminHeader' %> 後ほど以下の情報をlayouts/_adminHeader.html.erbに移動する-->
-       <div class="container">
-        <div class="row">
-          <div class="col-md-3">
-            <div class="logo user_logo">
-              BIGAPPLE
-            </div>
-          </div>
-          <div class="col-md-9">
-            <div class="row">
-              <div class="col-md-12">
-                <!--商品検索フォーム-->
-                <%= search_form_for @q,enforce_utf8: false do |f| %>
-                  <%= f.search_field :title_name_cont %>
-                  <span class="glyphicon glyphicon-search search_icon"></span>
-                <% end %>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-md-12">
-                <div class="nav">
-                  <ul>
-                    <% if user_signed_in? %>
-                      <li><%= link_to 'My Page','#' %></li>
-                      <li><%= link_to 'View Cart', '#' %></li>
-                      <li><%= link_to 'Sign out',destroy_user_session_path, method: :delete %></li>
-                    <% else %>
-                      <li><%= link_to 'Home',items_path %></li>
-                      <li><%= link_to 'Sign in',new_user_session_path %></li>
-                      <li><%= link_to 'Sign up',new_user_registration_path %></li>
-                    <% end %>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+       <%= render 'layouts/adminHeader' %>
       <% else %>
         <%= render 'layouts/userHeader' %>
       <% end %>


### PR DESCRIPTION
・利用者ヘッダーをlayout/_userHeader.html.erbに反映
・商品詳細画面遷移時に検索フォームの初期化処理対応漏れ追加

検索フォームをヘッダーに含めた事により各画面での検索フォーム初期化処理が必要となってしまったため、
ひとまず商品一覧画面、商品詳細画面のみ検索フォームを表示するように修正しました。