### PR TITLE
商品一覧画面　ジャンル検索

### DIFF
--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -46,8 +46,9 @@ ul.genre_list{
   width: 100%;
   padding-left: 0px;
 }
-ul.genre_list > li{
+ul.genre_list >a> li{
   height: 50px;
+  padding: 15px 5px;
   border:1px solid white;
   list-style: none;
   box-sizing: border-box;
@@ -55,11 +56,9 @@ ul.genre_list > li{
 }
 ul.genre_list a{
   color:#000;
-  list-style: none;
 }
-.genre_image{
-  height: 50px;
-  width: 50px;
+ul.genre_list > a > li:hover{
+  background-color:#ffded5;
 }
 
 // 商品詳細画面

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,6 +15,6 @@ class ItemsController < ApplicationController
     @items = @q.result(distinct: true)
   end
   def search_params
-    params.require(:q).permit(:title_name_cont)
+    params.require(:q).permit(:title_name_cont,:genre_id_eq)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,4 @@ class ItemsController < ApplicationController
     @q = Item.search(params[:q])
     @items = @q.result(distinct: true)
   end
-  def search_params
-    params.require(:q).permit(:title_name_cont,:genre_id_eq)
-  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,7 +6,7 @@
       </div>
       <ul class="genre_list">
       <% @genres.each do |genre| %>
-        <%= link_to items_path,target: "self" do %>
+        <%= link_to root_path(q:{genre_id_eq: genre.id}) do %>
           <li><%= genre.genre_name %></li>
         <% end %>
       <% end %>

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -9,7 +9,7 @@
      <div class="row">
        <div class="col-md-12">
          <!--商品検索フォーム-->
-         <% if request.path == root_path || request.path.include?('items/') %>
+         <% if request.path == root_path || request.path == items_path ||request.path.include?('items/') %>
            <%= search_form_for @q,enforce_utf8: false do |f| %>
              <%= f.search_field :title_name_cont %>
              <span class="glyphicon glyphicon-search search_icon"></span>


### PR DESCRIPTION
ジャンル検索機能を追加
- search_paramsにgenre_id_eq(genre_idが等しいもの)のパラメータを追加
- 商品一覧画面のviewのジャンル一覧のリンクを以下に修正
`  <%= link_to root_path(q:{genre_id_eq: genre.id}) do %>`
link_toに指定するアクションメソッドの引数に、「q」を追加、「qのgenre_id_eq」にgenre_idを設定
⇒これでrunsackがindexの処理内で検索条件として「パラメータのgenre_idに等しいもの」を使用しくれるようです。

※検索フォームの表示判定がまだおかしかったので、その修正を含めてしまいました（_userHeader.html.erb)