### PR TITLE
商品一覧画面　アーティスト名検索の追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -145,6 +145,11 @@ footer{
   margin: -30px;
   top:42px;
 }
+#item_category{
+  color:#000;
+  height: 1.8em;
+  border-radius: 2px;
+}
 // サインアップ・ログインフォーム
 .form-div{
   width: 80%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -132,7 +132,7 @@ footer{
   height: 100%;
   vertical-align: bottom;
 }
-#q_title_name_cont{
+#q_title_name_cont,#q_artist_cont{
   margin-top:5px;
   width: 300px;
   color: #000;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,6 +15,6 @@ class ItemsController < ApplicationController
     @items = @q.result(distinct: true)
   end
   def search_params
-    params.require(:q).permit(:title_name_cont)
+    params.require(:q).permit(:title_name_cont,:artist_cont)
   end
 end

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -13,6 +13,7 @@
            <%= search_form_for @q,enforce_utf8: false do |f| %>
              <%= f.search_field :title_name_cont %>
              <span class="glyphicon glyphicon-search search_icon"></span>
+             <%= select :item,:category,[['タイトル',1],['アーティスト',2]],:onchange => 'change_search_category()'%>
            <% end %>
          <% end %>
        </div>
@@ -37,3 +38,19 @@
    </div>
  </div>
 </div>
+<script>
+$(function($) {
+  // 検索方法の選択切り替え
+    $('#item_category').change(function() {
+        var search_input = $("input[type='search']")
+        var category = $('#item_category option:selected').val();
+        if(category == 1){
+          search_input.attr("name","q[title_name_cont]")
+          search_input.attr("id","q_title_name_cont")
+        }else{
+          search_input.attr("name","q[artist_cont]")
+          search_input.attr("id","q_artist_cont")
+        }
+    });
+});
+</script>

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -13,7 +13,7 @@
            <%= search_form_for @q,enforce_utf8: false do |f| %>
              <%= f.search_field :title_name_cont %>
              <span class="glyphicon glyphicon-search search_icon"></span>
-             <%= select :item,:category,[['タイトル',1],['アーティスト',2]],:onchange => 'change_search_category()'%>
+             <%= select :item,:category,[['タイトル',1],['アーティスト',2]]%>
            <% end %>
          <% end %>
        </div>


### PR DESCRIPTION
・アーティスト検索機能を追加
jQueryで、プルダウンの選択が行われたイベントを検知して、検索フォームのname,idを、
商品名検索用とアーティスト名検索用それぞれ書き換えています
ransackは渡された要素のnameかidをキーにして、何をどう検索するか、を判断しているようなので
検索フォームのname,idの書き換えで殆どの処理が完結しました。