### PR TITLE
商品一覧画面・詳細画面　アーティスト名検索の対応不備修正、最新のmasterブランチのmigrationに従ってschema.rbの更新”

### DIFF
--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -13,7 +13,7 @@
            <%= search_form_for @q,enforce_utf8: false do |f| %>
              <%= f.search_field :title_name_cont %>
              <span class="glyphicon glyphicon-search search_icon"></span>
-             <%= select :item,:category,[['タイトル',1],['アーティスト',2]]%>
+             <%= select_tag 'item[category]', options_for_select([['タイトル',1],['アーティスト',2]]) %>
            <% end %>
          <% end %>
        </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20180424052530) do
-
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
すみません、アーティスト名検索の機能を追加した状態で商品詳細画面に遷移するとエラーとなっていました。
対応版のブランチになります。