### PR TITLE
カート詳細画面・購入手続き画面の連携

### DIFF
--- a/app/assets/stylesheets/carts.scss
+++ b/app/assets/stylesheets/carts.scss
@@ -64,3 +64,6 @@
 .count_num{
 	width: 50px;
 }
+.alert_div{
+	margin-top: 30px;
+}

--- a/app/assets/stylesheets/carts.scss
+++ b/app/assets/stylesheets/carts.scss
@@ -57,6 +57,10 @@
 .item_name{
 	font-size: 16px;
 }
-.table .red-border-btn{
+.table .red-border-btn,
+.table .red-btn{
 	width: 100px;
+}
+.count_num{
+	width: 50px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 		if session[:cart_id]
 			@cart = Cart.find(session[:cart_id])
 		else
-			@cart = cart.create
+			@cart = Cart.create
 			session[:cart_id] = @cart.id
 		end
 	end

--- a/app/controllers/items_cart_controller.rb
+++ b/app/controllers/items_cart_controller.rb
@@ -15,8 +15,7 @@ class ItemsCartController < ApplicationController
       if items_cart.save
         # 在庫を減らす
         items_stock_update(item_id,1,true)
-        #TODO:カート詳細へのリダイレクトに修正すること
-        redirect_to item_path(item_id)
+        redirect_to cart_path(current_cart)
       else
         redirect_to item_path(item_id)
       end
@@ -26,8 +25,7 @@ class ItemsCartController < ApplicationController
       if  items_cart.update(count: latest_count)
         # 在庫を減らす
         items_stock_update(item_id,1,true)
-        #TODO:カート詳細へのリダイレクトに修正すること
-        redirect_to item_path(item_id)
+        redirect_to cart_path(current_cart)
       else
         redirect_to item_path(item_id)
       end

--- a/app/views/carts/check.html.erb
+++ b/app/views/carts/check.html.erb
@@ -97,7 +97,7 @@
       </div>
       <div class="row">
         <div class="cart_summary">
-          <%= link_to "キャンセル", "#" ,class:"btn red-gray-btn btn-xs" %><br>
+          <%= link_to "キャンセル", cart_path(current_cart) ,class:"btn red-gray-btn btn-xs" %><br>
         </div>
         <div class="cart_summary">
           <%= f.submit "購入確定", "data-confirm" => "購入を確定しますか", class: "btn red-btn" %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,6 +1,11 @@
 <div class="container">
 	<div class="row">
 		<div class="col-lg-9">
+			<% if @cart.item_carts.count == 0 %>
+			<div class="alert alert-warning alert_div" role="alert" >
+  			カートに商品がありません
+			</div>
+			<% else %>
 			<table class="table">
 				<thead>
 					<tr>
@@ -26,6 +31,7 @@
 					</tbody>
 				<% end %>
 			</table>
+			<% end %>
 		</div>
 		<div class="col-lg-3 summary">
       <div class="row">
@@ -51,7 +57,11 @@
       </div>
       <div class="row">
         <div class="cart_summary">
-          <%= link_to "購入手続きへ",cart_check_path, class: "btn red-btn"%>
+					<% if @cart.item_carts.count == 0 %>
+						<%= link_to "購入手続きへ","#", class: "btn red-btn", :disabled => true %>
+					<% else %>
+          	<%= link_to "購入手続きへ",cart_check_path, class: "btn red-btn"%>
+					<% end %>
         </div>
       </div>
     </div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -18,8 +18,8 @@
 								<td><%= link_to "#{item_cart.item.artist}/ #{item_cart.item.title_name}",item_path(item_cart.item.id) %></td>
 								<td>¥<%= item_cart.item.price.to_s(:delimited) %></td>
 								<td><%= form_for(item_cart, url: items_cart_path(item_cart), method: :patch) do |f| %>
-									<%= f.number_field :count %>
-									<%= f.submit "数量変更" %>
+									<%= f.number_field :count ,class: "count_num"%>
+									<%= f.submit "数量変更",class: "btn red-btn btn-xs" %>
 									<% end %>
 								<td><%= link_to "削除", items_cart_path(item_cart),method: :delete, class: "btn red-border-btn btn-xs"%></td>
 							</tr>
@@ -28,12 +28,32 @@
 			</table>
 		</div>
 		<div class="col-lg-3 summary">
-						<p>商品合計(数量)</p><br>
-						<p>合計金額</p><br>
-						<p>¥<%= @total_price %></p><br>
-						<p>合計個数</p>
-						<p><%= @total_count %><p><br>
-			<%= link_to "購入手続きへ", class: "btn red-border-btn btn-xs"%>
-		</div>
+      <div class="row">
+        <div class="heading">
+          <p>商品小計(数量)</p>
+        </div>
+      </div>
+      <div class="row">
+       <div class="col-lg-6 cart_summary">
+         合計金額
+       </div>
+       <div class="col-lg-6 cart_summary">
+         ¥<%= @total_price.to_s(:delimited) %>
+       </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-6 cart_summary">
+          合計個数
+        </div>
+        <div class="col-lg-6 cart_summary">
+          <%= @total_count %>個
+        </div>
+      </div>
+      <div class="row">
+        <div class="cart_summary">
+          <%= link_to "購入手続きへ",cart_check_path, class: "btn red-btn"%>
+        </div>
+      </div>
+    </div>
 	</div>
 </div>

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -25,7 +25,7 @@
                <li>UserName:　<%= current_user.last_name %>  <%= current_user.first_name %> 　　</li>
                <li><%= link_to '　Home',root_path %></li>
                <li><%= link_to '　My Page',user_path(current_user.id) %></li>
-               <li><%= link_to '　View Cart', '#' %></li>
+               <li><%= link_to '　View Cart', cart_path(current_cart) %></li>
                <li><%= link_to '　Sign out',destroy_user_session_path, method: :delete %></li>
              <% else %>
                <li><%= link_to '　Home',items_path %></li>


### PR DESCRIPTION
・ヘッダーにカート詳細画面遷移を追加
・商品詳細画面カートに追加ボタンからカート詳細画面への遷移を追加
・カート詳細画面のデザインを一部修正
・購入手続き画面のキャンセルボタンからカート詳細画面への遷移を追加