### PR TITLE
カートの有無判定修正、カートの商品数の表示バッジ追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -171,6 +171,9 @@ footer{
   height: 1.8em;
   border-radius: 2px;
 }
+.badge-red{
+  background-color: red;
+}
 // サインアップ・ログインフォーム
 .form-div{
   width: 80%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,33 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
  helper_method :current_cart
+ helper_method :current_cart_inside
 
 	def current_cart
 		if session[:cart_id]
 			@cart = Cart.find(session[:cart_id])
-		else
-			@cart = Cart.create
+		elsif Cart.find_by(:user_id => current_user.id)
+      @cart = Cart.find_by(:user_id => current_user.id)
+      session[:cart_id] = @cart.id
+    else
+			@cart = Cart.create(
+        :user_id => current_user.id
+      )
 			session[:cart_id] = @cart.id
 		end
 	end
+
+  def current_item_count
+    if session[:cart_id]
+      cart = Cart.find(session[:cart_id])
+      count = cart.item_carts.count
+    elsif Cart.find_by(:user_id => current_user)
+      cart = Cart.find_by(:user_id => current_user)
+      count = cart.item_carts.count
+    else
+      count = 0
+    end
+      count
+  end
+
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -65,6 +65,7 @@ class CartsController < ApplicationController
 				item_cart.destroy
 			end
 			cart.destroy
+			session[:cart_id] = nil
 		else
 			flash.now[:error] = "購入に失敗しました"
 		end

--- a/app/views/layouts/_userHeader.html.erb
+++ b/app/views/layouts/_userHeader.html.erb
@@ -25,7 +25,12 @@
                <li>UserName:　<%= current_user.last_name %>  <%= current_user.first_name %> 　　</li>
                <li><%= link_to '　Home',root_path %></li>
                <li><%= link_to '　My Page',user_path(current_user.id) %></li>
-               <li><%= link_to '　View Cart', cart_path(current_cart) %></li>
+               <li>
+                 <%= link_to '　View Cart', cart_path(current_cart) %>
+                 <% if current_item_count > 0 %>
+                    <span class="badge badge-pill badge-red"><%= current_item_count %></span>
+                 <% end %>
+               </li>
                <li><%= link_to '　Sign out',destroy_user_session_path, method: :delete %></li>
              <% else %>
                <li><%= link_to '　Home',items_path %></li>


### PR DESCRIPTION
・既存カートの取得条件に、DBのCartテーブルにcurrent_userのIDがあれば取得を追加
・購入後にセッションのcart_idを破棄
・メニューのViewCartの横に現在のアイテム数表示を追加