### PR TITLE
ヘルパーメソッド指定が抜けていたため修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
  helper_method :current_cart
- helper_method :current_cart_inside
+ helper_method :current_item_count
 
 	def current_cart
 		if session[:cart_id]


### PR DESCRIPTION
すみません、関数名を変更した際に漏れていました。